### PR TITLE
JSON.stringify path output to script for Windows

### DIFF
--- a/meteor-imports.js
+++ b/meteor-imports.js
@@ -68,7 +68,7 @@ module.exports = function(/*source*/) {
       if (pkg.source)
         output += 'Package._define("' + pkg.name + '", ' + pkg.source + ');\n';
       else
-        output += 'require("' + path.join(meteorBuild, pkg.path) + '");\n';
+        output += 'require(' + JSON.stringify(path.join(meteorBuild, pkg.path)) + ');\n';
     }
 
     output += 'var mr = Package["modules-runtime"];\n';


### PR DESCRIPTION
Windows uses backslashes, which need to be escaped before being written to a javascript block. I used JSON.stringify to do the escaping. This may catch other edge cases as well.